### PR TITLE
[feat] add map Values function; allow CombineSlices to take no args (BREAKING CHANGE)

### DIFF
--- a/map.go
+++ b/map.go
@@ -1,9 +1,19 @@
 package generic
 
+// Keys returns the map keys as a slice
 func Keys[K comparable, V any](m map[K]V) []K {
 	slice := make([]K, 0, len(m))
 	for k := range m {
 		slice = append(slice, k)
+	}
+	return slice
+}
+
+// Values returns the map values as a slice
+func Values[K comparable, V any](m map[K]V) []V {
+	slice := make([]V, 0, len(m))
+	for _, v := range m {
+		slice = append(slice, v)
 	}
 	return slice
 }

--- a/map_test.go
+++ b/map_test.go
@@ -43,6 +43,55 @@ func TestKeys(t *testing.T) {
 	})
 }
 
+func TestValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts values from map", func(t *testing.T) {
+		t.Parallel()
+
+		m := map[string]int{
+			"a": 1,
+			"b": 2,
+			"c": 3,
+		}
+
+		values := generic.Values(m)
+
+		t.Log("Should extract all values from map")
+		assert.Len(t, values, 3)
+		assert.Contains(t, values, 1)
+		assert.Contains(t, values, 2)
+		assert.Contains(t, values, 3)
+	})
+
+	t.Run("handles empty map", func(t *testing.T) {
+		t.Parallel()
+
+		m := map[int]string{}
+		values := generic.Values(m)
+
+		t.Log("Should return empty slice for empty map")
+		assert.Empty(t, values)
+	})
+
+	t.Run("handles duplicate values", func(t *testing.T) {
+		t.Parallel()
+
+		m := map[string]int{
+			"a": 1,
+			"b": 1,
+			"c": 2,
+		}
+
+		values := generic.Values(m)
+
+		t.Log("Should include duplicate values in the result")
+		assert.Len(t, values, 3)
+		assert.Contains(t, values, 1)
+		assert.Contains(t, values, 2)
+	})
+}
+
 func TestCompareKeys(t *testing.T) {
 	t.Parallel()
 
@@ -368,7 +417,7 @@ func TestAllKeys(t *testing.T) {
 		}
 
 		result := generic.AllKeys(m, func(k string) bool {
-			return strings.HasPrefix(k, "test_");
+			return strings.HasPrefix(k, "test_")
 		})
 
 		t.Log("Should return true if all keys satisfy the condition")
@@ -379,13 +428,13 @@ func TestAllKeys(t *testing.T) {
 		t.Parallel()
 
 		m := map[string]int{
-			"test_a": 1,
-			"test_b": 2,
+			"test_a":  1,
+			"test_b":  2,
 			"other_c": 3,
 		}
 
 		result := generic.AllKeys(m, func(k string) bool {
-			return strings.HasPrefix(k, "test_");
+			return strings.HasPrefix(k, "test_")
 		})
 
 		t.Log("Should return false if any key does not satisfy the condition")
@@ -400,13 +449,13 @@ func TestAnyKey(t *testing.T) {
 		t.Parallel()
 
 		m := map[string]int{
-			"a": 1,
+			"a":      1,
 			"test_b": 2,
-			"c": 3,
+			"c":      3,
 		}
 
 		result := generic.AnyKey(m, func(k string) bool {
-			return strings.HasPrefix(k, "test_");
+			return strings.HasPrefix(k, "test_")
 		})
 
 		t.Log("Should return true if any key satisfies the condition")
@@ -423,7 +472,7 @@ func TestAnyKey(t *testing.T) {
 		}
 
 		result := generic.AnyKey(m, func(k string) bool {
-			return strings.HasPrefix(k, "test_");
+			return strings.HasPrefix(k, "test_")
 		})
 
 		t.Log("Should return false if no keys satisfy the condition")
@@ -444,7 +493,7 @@ func TestAllValues(t *testing.T) {
 		}
 
 		result := generic.AllValues(m, func(v int) bool {
-			return v > 0;
+			return v > 0
 		})
 
 		t.Log("Should return true if all values satisfy the condition")
@@ -461,7 +510,7 @@ func TestAllValues(t *testing.T) {
 		}
 
 		result := generic.AllValues(m, func(v int) bool {
-			return v > 0;
+			return v > 0
 		})
 
 		t.Log("Should return false if any value does not satisfy the condition")
@@ -511,7 +560,7 @@ func TestAnyValue(t *testing.T) {
 		}
 
 		result := generic.AnyValue(m, func(v int) bool {
-			return v < 0;
+			return v < 0
 		})
 
 		t.Log("Should return true if any value satisfies the condition")
@@ -528,7 +577,7 @@ func TestAnyValue(t *testing.T) {
 		}
 
 		result := generic.AnyValue(m, func(v int) bool {
-			return v < 0;
+			return v < 0
 		})
 
 		t.Log("Should return false if no values satisfy the condition")

--- a/slice.go
+++ b/slice.go
@@ -79,24 +79,26 @@ func ReplaceOrAppend[T any](s []T, n T, filter func(T) bool) []T {
 }
 
 // CombineSlices may return the first slice if it is the only slice with elements.  A copy
-// is only made if it has to be made.
-func CombineSlices[T any](first []T, more ...[]T) []T {
-	if len(more) == 0 {
-		return first
+// is only made if it has to be made. For no input, nil is returned.
+func CombineSlices[T any](slices ...[]T) []T {
+	switch len(slices) {
+	case 0:
+		return nil
+	case 1:
+		return slices[0]
 	}
-	if len(first) == 0 && len(more) == 1 {
-		return more[0]
-	}
-	total := len(first)
-	for _, m := range more {
+	return CombineSlicesCopy[T](slices...)
+}
+
+// CombineSlicesCopy combines all of its input slices, always
+// returning a new slice, For no input, an empty slice is returned.
+func CombineSlicesCopy[T any](slices ...[]T) []T {
+	var total int
+	for _, m := range slices {
 		total += len(m)
 	}
-	if total == len(first) {
-		return first
-	}
-	combined := make([]T, len(first), total)
-	copy(combined, first)
-	for _, m := range more {
+	combined := make([]T, 0, total)
+	for _, m := range slices {
 		combined = append(combined, m...)
 	}
 	return combined

--- a/slice_test.go
+++ b/slice_test.go
@@ -344,52 +344,147 @@ func TestCountMatchingElements(t *testing.T) {
 func TestCombineSlices(t *testing.T) {
 	t.Parallel()
 
+	t.Run("returns nil for no input", func(t *testing.T) {
+		t.Parallel()
+
+		result := generic.CombineSlices[int]()
+		t.Log("Should return nil when no slices are provided")
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns single slice when only one is provided", func(t *testing.T) {
+		t.Parallel()
+
+		slice := []int{1, 2, 3}
+		result := generic.CombineSlices(slice)
+		t.Log("Should return the same slice when only one slice is provided")
+		assert.Equal(t, slice, result)
+	})
+
+	t.Run("returns second slice if first is empty", func(t *testing.T) {
+		t.Parallel()
+
+		slice1 := []int{}
+		slice2 := []int{4, 5, 6}
+		result := generic.CombineSlices(slice1, slice2)
+		t.Log("Should return the second slice if the first slice is empty")
+		assert.Equal(t, slice2, result)
+	})
+
+	t.Run("combines two non-empty slices", func(t *testing.T) {
+		t.Parallel()
+
+		slice1 := []int{1, 2}
+		slice2 := []int{3, 4}
+		result := generic.CombineSlices(slice1, slice2)
+		t.Log("Should combine two non-empty slices")
+		assert.Equal(t, []int{1, 2, 3, 4}, result)
+	})
+
 	t.Run("combines multiple slices", func(t *testing.T) {
 		t.Parallel()
 
-		s1 := []int{1, 2}
-		s2 := []int{3, 4}
-		s3 := []int{5, 6}
-
-		result := generic.CombineSlices(s1, s2, s3)
-
-		t.Log("Should combine all slices in order")
-		expected := []int{1, 2, 3, 4, 5, 6}
-		assert.Equal(t, expected, result)
+		slice1 := []int{1, 2}
+		slice2 := []int{3, 4}
+		slice3 := []int{5, 6}
+		result := generic.CombineSlices(slice1, slice2, slice3)
+		t.Log("Should combine all slices into one")
+		assert.Equal(t, []int{1, 2, 3, 4, 5, 6}, result)
 	})
 
-	t.Run("returns first slice if only one provided", func(t *testing.T) {
+	t.Run("handles empty slices in the middle", func(t *testing.T) {
 		t.Parallel()
 
-		s1 := []string{"a", "b", "c"}
-		result := generic.CombineSlices(s1)
-
-		t.Log("Should return first slice when only one is provided")
-		assert.Equal(t, s1, result)
+		slice1 := []int{1, 2}
+		slice2 := []int{}
+		slice3 := []int{3, 4}
+		result := generic.CombineSlices(slice1, slice2, slice3)
+		t.Log("Should skip empty slices and combine the rest")
+		assert.Equal(t, []int{1, 2, 3, 4}, result)
 	})
 
-	t.Run("handles empty first slice", func(t *testing.T) {
+	t.Run("avoids copying when returning the first slice", func(t *testing.T) {
 		t.Parallel()
 
-		s1 := []int{}
-		s2 := []int{1, 2, 3}
-
-		result := generic.CombineSlices(s1, s2)
-
-		t.Log("Should return second slice when first is empty")
-		assert.Equal(t, s2, result)
+		slice := []int{1, 2, 3}
+		result := generic.CombineSlices(slice)
+		t.Log("Should return the same slice without making a copy")
+		assert.Equal(t, slice, result)
 	})
 
-	t.Run("handles all empty slices", func(t *testing.T) {
+	t.Run("returns first slice if it contains all elements", func(t *testing.T) {
 		t.Parallel()
 
-		s1 := []int{}
-		s2 := []int{}
+		slice1 := []int{1, 2, 3}
+		slice2 := []int{}
+		result := generic.CombineSlices(slice1, slice2)
+		t.Log("Should return the first slice if it contains all elements")
+		assert.Equal(t, slice1, result)
+	})
+}
 
-		result := generic.CombineSlices(s1, s2)
+func TestCombineSlicesCopy(t *testing.T) {
+	t.Parallel()
 
-		t.Log("Should return empty slice when all inputs are empty")
+	t.Run("returns empty slice for no input", func(t *testing.T) {
+		t.Parallel()
+
+		result := generic.CombineSlicesCopy[int]()
+		t.Log("Should return an empty slice when no slices are provided")
+		assert.NotNil(t, result)
 		assert.Empty(t, result)
+	})
+
+	t.Run("returns a new slice when only one is provided", func(t *testing.T) {
+		t.Parallel()
+
+		slice := []int{1, 2, 3}
+		result := generic.CombineSlicesCopy(slice)
+		t.Log("Should return a new slice with the same elements when only one slice is provided")
+		assert.Equal(t, slice, result)
+		assert.False(t, &slice[0] == &result[0], "The underlying arrays should not have the same memory address")
+	})
+
+	t.Run("combines two non-empty slices", func(t *testing.T) {
+		t.Parallel()
+
+		slice1 := []int{1, 2}
+		slice2 := []int{3, 4}
+		result := generic.CombineSlicesCopy(slice1, slice2)
+		t.Log("Should combine two non-empty slices into a new slice")
+		assert.Equal(t, []int{1, 2, 3, 4}, result)
+	})
+
+	t.Run("combines multiple slices", func(t *testing.T) {
+		t.Parallel()
+
+		slice1 := []int{1, 2}
+		slice2 := []int{3, 4}
+		slice3 := []int{5, 6}
+		result := generic.CombineSlicesCopy(slice1, slice2, slice3)
+		t.Log("Should combine all slices into a new slice")
+		assert.Equal(t, []int{1, 2, 3, 4, 5, 6}, result)
+	})
+
+	t.Run("handles empty slices in the middle", func(t *testing.T) {
+		t.Parallel()
+
+		slice1 := []int{1, 2}
+		slice2 := []int{}
+		slice3 := []int{3, 4}
+		result := generic.CombineSlicesCopy(slice1, slice2, slice3)
+		t.Log("Should skip empty slices and combine the rest into a new slice")
+		assert.Equal(t, []int{1, 2, 3, 4}, result)
+	})
+
+	t.Run("always returns a new slice even if total length matches first slice", func(t *testing.T) {
+		t.Parallel()
+
+		slice1 := []int{1, 2, 3}
+		result := generic.CombineSlicesCopy(slice1)
+		t.Log("Should return a new slice even if the total length matches the first slice")
+		assert.Equal(t, slice1, result)
+		assert.False(t, &slice1[0] == &result[0], "The underlying arrays should not have the same memory address")
 	})
 }
 


### PR DESCRIPTION
The Values function is obvious.
CombineSlices now all can have no arguments, though in that case, the generic binding must be provided explicitly.